### PR TITLE
normalizes plugin styles with WordPress.com version

### DIFF
--- a/css/ac-style.css
+++ b/css/ac-style.css
@@ -41,6 +41,7 @@
 	text-decoration: none !important;
 	opacity: 0.85;
 	border-bottom: none !important;			/* some themes ad dotted underlines, that won't look nice */
+	box-shadow: none !important;
 }
 
 .wpa-about:hover, .wa_infobox a:hover {


### PR DESCRIPTION
this CSS update remvoves the WordAds icon and bumps up the "About these ads " label a notch.

![screen shot 2015-12-17 at 11 14 25](https://cloud.githubusercontent.com/assets/57050/11868488/08d6c3c6-a4b0-11e5-821c-f2e980c5d2d0.png)
